### PR TITLE
解决加载Asset，没有加载所有依赖Bundle的Bug

### DIFF
--- a/Assets/xasset/Editor/Build/Pipeline/DefaultAssetBundleManifest.cs
+++ b/Assets/xasset/Editor/Build/Pipeline/DefaultAssetBundleManifest.cs
@@ -19,7 +19,7 @@ namespace xasset.editor
 
         public string[] GetDependencies(string assetBundle)
         {
-            return _manifest.GetAllDependencies(assetBundle);
+            return _manifest.GetDirectDependencies(assetBundle);
         }
 
         public string GetAssetBundleHash(string assetBundle)

--- a/Assets/xasset/Editor/Build/Task/BuildVersions.cs
+++ b/Assets/xasset/Editor/Build/Task/BuildVersions.cs
@@ -94,8 +94,19 @@ namespace xasset.editor
                 foreach (var dependency in dependencies)
                     if (map.TryGetValue(dependency, out var dep))
                         deps.Add(dep.id);
-
                 asset.deps = deps.ToArray();
+            }
+
+            foreach (var asset in assets)
+            {
+                var depBundles = new List<int>();
+                foreach (var depAsset in asset.deps)
+                {
+                    var depBundle = assets[depAsset].bundle;
+                    if (depBundle != asset.bundle && !depBundles.Contains(depBundle))
+                        depBundles.Add(depBundle);
+                }
+                asset.depBundles = depBundles.ToArray();
             }
 
             manifest.Clear();
@@ -144,7 +155,7 @@ namespace xasset.editor
                 foreach (var asset in assets)
                 {
                     if (!manifest.TryGetAsset(asset, out var result)) continue;
-                    set.Add(result.bundle); 
+                    set.Add(result.bundle);
                 }
 
                 set.ExceptWith(packed);
@@ -159,9 +170,9 @@ namespace xasset.editor
                     manifest = manifest,
                     assets = bundles,
                     deliveryMode = group.deliveryMode
-                }); 
-            } 
+                });
+            }
             manifest.groups = manifestGroups.ToArray();
-        } 
+        }
     }
 }

--- a/Assets/xasset/Runtime/API/Assets.cs
+++ b/Assets/xasset/Runtime/API/Assets.cs
@@ -95,7 +95,7 @@ namespace xasset
             if (!IsDownloaded(bundle))
                 return false;
 
-            foreach (var dependency in bundle.deps)
+            foreach (var dependency in asset.depBundles)
                 if (!IsDownloaded(bundles[dependency]))
                     return false;
 

--- a/Assets/xasset/Runtime/API/Requests/Dependencies.cs
+++ b/Assets/xasset/Runtime/API/Requests/Dependencies.cs
@@ -48,10 +48,9 @@ namespace xasset
         private void LoadAll()
         {
             var bundles = asset.manifest.bundles;
-            var bundle = bundles[asset.bundle];
             _bundleRequest = Load(bundles[asset.bundle]);
-            if (bundle.deps == null || bundle.deps.Length <= 0) return;
-            foreach (var dep in bundle.deps)
+            if (asset.depBundles == null || asset.depBundles.Length <= 0) return;
+            foreach (var dep in asset.depBundles)
                 Load(bundles[dep]);
         }
 

--- a/Assets/xasset/Runtime/API/Requests/GetDownloadSizeRequest.cs
+++ b/Assets/xasset/Runtime/API/Requests/GetDownloadSizeRequest.cs
@@ -46,7 +46,7 @@ namespace xasset
                             var bundles = group.manifest.bundles;
                             var bundle = bundles[asset];
                             set.Add(bundle); 
-                            foreach (var dep in bundle.deps)
+                            foreach (var dep in group.manifest.assets[asset].depBundles)
                                 set.Add(bundles[dep]);
                         }
                     }
@@ -58,7 +58,7 @@ namespace xasset
                             var bundles = asset.manifest.bundles;
                             var bundle = bundles[asset.bundle];
                             set.Add(bundle);
-                            foreach (var dep in bundle.deps)
+                            foreach (var dep in asset.depBundles)
                                 set.Add(bundles[dep]);
                         }
                     }

--- a/Assets/xasset/Runtime/API/Requests/ReloadRequest.cs
+++ b/Assets/xasset/Runtime/API/Requests/ReloadRequest.cs
@@ -51,7 +51,7 @@ namespace xasset
                 var last = pair.Value.info;
                 var bundle = last.manifest.bundles[last.bundle];
                 if (!changed.Contains(bundle.name) &&
-                    !Array.Exists(bundle.deps, i => changed.Contains(last.manifest.bundles[i].name))) continue;
+                    !Array.Exists(last.depBundles, i => changed.Contains(last.manifest.bundles[i].name))) continue;
                 if (!versions.TryGetAsset(last.path, out var value)) continue;
                 pair.Value.info = value;
                 Reload(pair.Value);

--- a/Assets/xasset/Runtime/Config/Manifest.cs
+++ b/Assets/xasset/Runtime/Config/Manifest.cs
@@ -47,6 +47,7 @@ namespace xasset
         public string name;
         public int[] deps = Array.Empty<int>();
         public int bundle;
+        public int[] depBundles = Array.Empty<int>();
         public int dir;
         public AddressMode addressMode = AddressMode.LoadByPath;
         public int id { get; set; }


### PR DESCRIPTION
Asset.Load，处理依赖应该根据于资源本身所依赖的所有资源所在的Bundle进行处理，这是一个天然没有循环依赖的处理方式。
而直接将资源所在Bundle的所依赖全部Bundle进行加载，这种做法有点过于暴力，可能一次加载过多bundle的问题。